### PR TITLE
Fix for eviction of backups.

### DIFF
--- a/docker/postgres/storage_pgbackrest.py
+++ b/docker/postgres/storage_pgbackrest.py
@@ -195,10 +195,27 @@ class BackRestVault(storage.Vault):
 
         return self.folder, self.metrics, self.console
 
+    #def create_time(self):
+    #    foldername = self.get_id()
+    #    self.__log.info("folder name logged: %s" % self.foldername)
+    #    d = datetime.strptime(foldername, VAULT_NAME_FORMAT)
+    #    return time.mktime(d.timetuple())
+    
     def create_time(self):
         foldername = self.get_id()
-        d = datetime.strptime(foldername, VAULT_NAME_FORMAT)
-        return time.mktime(d.timetuple())
+        self.__log.info("folder name logged: %s" % foldername)
+
+        # If foldername has the 'backup-' prefix, return a default time
+        if foldername.startswith("backup-"):
+            return time.time()  # Returning the current timestamp as a fallback
+
+        try:
+            d = datetime.strptime(foldername, VAULT_NAME_FORMAT)
+            return time.mktime(d.timetuple())
+        except ValueError as e:
+            self.__log.error("Failed to parse datetime from foldername: %s, error: %s", foldername, str(e))
+            return time.time()  # Returning the current timestamp as a fallback
+    
     #
     # def __exit__(self, tpe, exception, tb):
     #     self.__log.info("Close vault")

--- a/docker/postgres/storage_pgbackrest.py
+++ b/docker/postgres/storage_pgbackrest.py
@@ -195,15 +195,9 @@ class BackRestVault(storage.Vault):
 
         return self.folder, self.metrics, self.console
 
-    #def create_time(self):
-    #    foldername = self.get_id()
-    #    self.__log.info("folder name logged: %s" % self.foldername)
-    #    d = datetime.strptime(foldername, VAULT_NAME_FORMAT)
-    #    return time.mktime(d.timetuple())
     
     def create_time(self):
         foldername = self.get_id()
-        self.__log.info("folder name logged: %s" % foldername)
 
         # If foldername has the 'backup-' prefix, return a default time
         if foldername.startswith("backup-"):


### PR DESCRIPTION
We had situation like below - 

`File "/opt/backup/storage_pgbackrest.py", line 200, in create_time
d = datetime.strptime(foldername, VAULT_NAME_FORMAT)
File "/usr/lib/python3.10/_strptime.py", line 568, in _strptime_datetime
tt, fraction, gmtoff_fraction = _strptime(data_string, format)
File "/usr/lib/python3.10/_strptime.py", line 349, in _strptime
raise ValueError("time data %r does not match format %r" %
ValueError: time data 'backup-20250305T063000009306' does not match format '%Y%m%dT%H%M'`

which cause issue with manual backups. So, we added a fix for above problem in the scope of this commit.