### PR TITLE
Excluding pg_hint_plan from pg_dump in case of external db.

### DIFF
--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -250,6 +250,7 @@ class PostgreSQLDumpWorker(Thread):
             database_backup_path = backups.build_database_backup_path(self.backup_id, database,
                                                                   self.namespace, self.external_backup_root)
 
+
             with open(database_backup_path, 'w+') as dump, \
                     open(self.stderr_file(database), "w+") as stderr:
                 start = time.time()

--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -271,8 +271,14 @@ class PostgreSQLDumpWorker(Thread):
                     exit_code = pg_dump_proc.wait()
 
                 if exit_code != 0:
+
                     with open(self.stderr_file(database)) as f:
-                        raise backups.BackupFailedException(database, '\n'.join(f.readlines()))
+                        stderr_contents = f.read()
+                        self.log.error("pg_dump stderr:\n{}".format(stderr_contents))
+                        raise backups.BackupFailedException(database, stderr_contents)
+
+                    #with open(self.stderr_file(database)) as f:
+                    #    raise backups.BackupFailedException(database, '\n'.join(f.readlines()))
 
                 self.pg_dump_proc = None
         if self.s3:

--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -183,8 +183,10 @@ class PostgreSQLDumpWorker(Thread):
         extension_flags = []
         if configs.is_external_pg():
             included_exts = self.get_included_extensions(database)
-            if included_exts:  # Only add --extension if there are extensions
-                extension_flags.extend(['--extension', ','.join(included_exts)])
+            if included_exts:
+            # Add each extension as a separate --extension flag
+                for ext in included_exts:
+                    extension_flags.extend(['--extension', ext])
 
         if int(self.parallel_jobs) > 1:
             command = ['{}/pg_dump'.format(self.bin_path),

--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -169,8 +169,6 @@ class PostgreSQLDumpWorker(Thread):
             if conn:
                 conn.close()
 
-
-
     def backup_single_database(self, database):
         self.log.info(self.log_msg("Start processing database '{}'.".format(database)))
         self.log.info(self.log_msg("Will use binaries: '{}' for backup.".format(self.bin_path)))
@@ -266,7 +264,6 @@ class PostgreSQLDumpWorker(Thread):
 
             database_backup_path = backups.build_database_backup_path(self.backup_id, database,
                                                                   self.namespace, self.external_backup_root)
-
 
             with open(database_backup_path, 'w+') as dump, \
                     open(self.stderr_file(database), "w+") as stderr:

--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -209,6 +209,7 @@ class PostgreSQLDumpWorker(Thread):
             if self.compression_level or self.compression_level == 0:
                 command.extend(['-Z', str(self.compression_level)])
 
+            self.log.info(self.log_msg("Running pg_dump command: {}".format(' '.join(command))))
 
             with open(self.stderr_file(database), "w+") as stderr:
                 start = time.time()
@@ -251,6 +252,7 @@ class PostgreSQLDumpWorker(Thread):
             database_backup_path = backups.build_database_backup_path(self.backup_id, database,
                                                                   self.namespace, self.external_backup_root)
 
+            self.log.info(self.log_msg("Running pg_dump command: {}".format(' '.join(command))))
 
             with open(database_backup_path, 'w+') as dump, \
                     open(self.stderr_file(database), "w+") as stderr:

--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -207,7 +207,6 @@ class PostgreSQLDumpWorker(Thread):
             if self.compression_level or self.compression_level == 0:
                 command.extend(['-Z', str(self.compression_level)])
 
-            self.log.info(self.log_msg("Running pg_dump command: {}".format(' '.join(command))))
 
             with open(self.stderr_file(database), "w+") as stderr:
                 start = time.time()
@@ -250,7 +249,6 @@ class PostgreSQLDumpWorker(Thread):
             database_backup_path = backups.build_database_backup_path(self.backup_id, database,
                                                                   self.namespace, self.external_backup_root)
 
-            self.log.info(self.log_msg("Running pg_dump command: {}".format(' '.join(command))))
 
             with open(database_backup_path, 'w+') as dump, \
                     open(self.stderr_file(database), "w+") as stderr:

--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -260,6 +260,8 @@ class PostgreSQLDumpWorker(Thread):
             if self.compression_level or self.compression_level == 0:
                 command.extend(['-Z', str(self.compression_level)])
 
+            self.log.info(self.log_msg("Running pg_dump command: {}".format(' '.join(command))))
+
             with open(self.stderr_file(database), "w+") as stderr:
                 start = time.time()
                 if self.encryption:
@@ -301,6 +303,7 @@ class PostgreSQLDumpWorker(Thread):
             database_backup_path = backups.build_database_backup_path(self.backup_id, database,
                                                                   self.namespace, self.external_backup_root)
 
+            self.log.info(self.log_msg("Running pg_dump command: {}".format(' '.join(command))))
 
             with open(database_backup_path, 'w+') as dump, \
                     open(self.stderr_file(database), "w+") as stderr:

--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -139,7 +139,7 @@ class PostgreSQLDumpWorker(Thread):
 
     def drop_pg_hint_plan_extension(self, database):
         connection_properties = configs.connection_properties()
-        connection_properties['dbname'] = database
+        connection_properties['database'] = database
         conn = None
         try:
             conn = psycopg2.connect(**connection_properties)
@@ -154,7 +154,7 @@ class PostgreSQLDumpWorker(Thread):
 
     def recreate_pg_hint_plan_extension(self, database):
         connection_properties = configs.connection_properties()
-        connection_properties['dbname'] = database
+        connection_properties['database'] = database
         conn = None
         try:
             conn = psycopg2.connect(**connection_properties)

--- a/docker/granular/pg_backup.py
+++ b/docker/granular/pg_backup.py
@@ -209,8 +209,6 @@ class PostgreSQLDumpWorker(Thread):
             if self.compression_level or self.compression_level == 0:
                 command.extend(['-Z', str(self.compression_level)])
 
-            self.log.info(self.log_msg("Running pg_dump command: {}".format(' '.join(command))))
-
             with open(self.stderr_file(database), "w+") as stderr:
                 start = time.time()
                 if self.encryption:
@@ -252,8 +250,6 @@ class PostgreSQLDumpWorker(Thread):
             database_backup_path = backups.build_database_backup_path(self.backup_id, database,
                                                                   self.namespace, self.external_backup_root)
 
-            self.log.info(self.log_msg("Running pg_dump command: {}".format(' '.join(command))))
-
             with open(database_backup_path, 'w+') as dump, \
                     open(self.stderr_file(database), "w+") as stderr:
                 start = time.time()
@@ -271,14 +267,8 @@ class PostgreSQLDumpWorker(Thread):
                     exit_code = pg_dump_proc.wait()
 
                 if exit_code != 0:
-
                     with open(self.stderr_file(database)) as f:
-                        stderr_contents = f.read()
-                        self.log.error("pg_dump stderr:\n{}".format(stderr_contents))
-                        raise backups.BackupFailedException(database, stderr_contents)
-
-                    #with open(self.stderr_file(database)) as f:
-                    #    raise backups.BackupFailedException(database, '\n'.join(f.readlines()))
+                        raise backups.BackupFailedException(database, '\n'.join(f.readlines()))
 
                 self.pg_dump_proc = None
         if self.s3:


### PR DESCRIPTION
Now its possible for users to configure list of extensions which they want to exclude from backups. By default, pg_hint_plan will be excluded as it caused issue while performing backup for azure pg.
Users can use next deployment param - For eg. 
excludedExtensions: "pg_stat_statements, plan,plpgsql" 
To exclude the extensions from backup.