### PR TITLE
Fix failed file path for failed backups

### DIFF
--- a/docker/postgres/storage_fs.py
+++ b/docker/postgres/storage_fs.py
@@ -286,5 +286,8 @@ class FSVault(storage.Vault):
     def __repr__(self):
         return "Vault(%s)" % os.path.basename(self.folder)
 
+    #def fail(self):
+    #    open(self.folder + self.__failed_filepath(), "w").close()
+
     def fail(self):
-        open(self.folder + self.__failed_filepath(), "w").close()
+        open(self.__failed_filepath(), "w").close()

--- a/docker/postgres/storage_fs.py
+++ b/docker/postgres/storage_fs.py
@@ -286,8 +286,5 @@ class FSVault(storage.Vault):
     def __repr__(self):
         return "Vault(%s)" % os.path.basename(self.folder)
 
-    #def fail(self):
-    #    open(self.folder + self.__failed_filepath(), "w").close()
-
     def fail(self):
         open(self.__failed_filepath(), "w").close()


### PR DESCRIPTION
Fixed issue with path of .failed file in backup-daemon.
Earlier the path was like - 
`[Errno 2] No such file or directory: '/backup-storage/pg15/20250506T0926/backup-storage/pg15/20250506T0926/.failed'`

Which was incorrect. 
So, it was fixed within scope of this commit.