### PR TITLE
Add short ID generation for backups and enhance pgbackrest service selection based on cluster state

### DIFF
--- a/docker/granular/backups.py
+++ b/docker/granular/backups.py
@@ -147,6 +147,8 @@ def get_key_name_by_backup_id(backup_id, namespace, external_backup_storage=None
         data = json.load(f)
         return data.get("key_name")
 
+def generate_short_id():
+    return datetime.datetime.now().strftime("%Y%m%dT%H%M")
 
 def generate_id():
     return datetime.datetime.now().strftime("%Y%m%dT%H%M%S%f")


### PR DESCRIPTION
- Introduced `generate_short_id` function for simplified backup ID generation.
- Implemented logic to determine the appropriate pgbackrest service based on the state of the cluster, querying the Patroni API for healthy replicas.